### PR TITLE
Remove /traffic_waypoint a prerequisite for waypoint_updater.

### DIFF
--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -45,7 +45,6 @@ class WaypointUpdater(object):
         rospy.wait_for_message('/current_pose', PoseStamped)
         self.current_pose_sub = rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
 
-        rospy.wait_for_message('/traffic_waypoint', Int32)
         self.traffic_waypoint_sub = rospy.Subscriber('/traffic_waypoint', Int32, self.traffic_cb)
 
         self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)


### PR DESCRIPTION
This PR unlocks waypoint_updater from depending on camera images. It is needed for testing on a parking lot in simulator.